### PR TITLE
Updates for new version of install-dylan-tool action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,8 +1,5 @@
 # To test changes to the install-dylan-tool Action we choose an arbitrary
-# project (pacman-catalog) to build and test. Unfortunately, this will only run
-# AFTER something is pushed to the "main" branch. Not sure how to fix that, but
-# it's not a big problem since no one will use it until a specific version is
-# tagged.
+# project (pacman-catalog) to build and test.
 
 name: build-and-test
 
@@ -13,7 +10,8 @@ on:
     branches:
       - main
 
-  # This enables the Run Workflow button on the Actions tab.
+  # This enables the Run Workflow button here:
+  # https://github.com/dylan-lang/install-dylan-tool/actions/workflows/build-and-test.yml
   workflow_dispatch:
 
 jobs:
@@ -21,24 +19,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: dylan-lang/install-dylan-tool@main
+      - uses: actions/checkout@v4
 
-      - name: Create workspace
-        run: |
-          ./dylan new workspace pc
-
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: dylan-lang/pacman-catalog
-          path: pc/pacman-catalog
+          path: pacman-catalog
+
+      # Use the local checkout of install-dylan-tool as a GitHub Action.
+      - uses: ./
 
       - name: Build pacman-catalog-test-suite
         run: |
-          cd pc
-          DYLAN_CATALOG=./pacman-catalog ../dylan update
-          ../dylan-compiler -build -jobs 3 pacman-catalog-test-suite
+          cd pacman-catalog
+          DYLAN_CATALOG=. dylan update
+          dylan build pacman-catalog-test-suite
 
       - name: Run pacman-catalog-test-suite
         run: |
-          cd pc
-          DYLAN_CATALOG=./pacman-catalog _build/bin/pacman-catalog-test-suite
+          cd pacman-catalog
+          DYLAN_CATALOG=. _build/bin/pacman-catalog-test-suite --report surefire --report-file _build/pacman-catalog-tests.xml
+
+      - name: Publish test report
+        if: success() || failure()
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: '**/_build/*-tests.xml'

--- a/README.md
+++ b/README.md
@@ -8,33 +8,23 @@ invokes the
 To install the latest dylan-tool release:
 
 ```yaml
-    - uses: dylan-lang/install-dylan-tool@v2
+    - uses: dylan-lang/install-dylan-tool@v3
 ```
 
 To install a specific released version:
 
 ```yaml
-    - uses: dylan-lang/install-dylan-tool@v2
+    - uses: dylan-lang/install-dylan-tool@v3
       with:
-        tag: v1.2.3
+        tag: v0.12.0
 ```
 
 `tag` must exactly match a tagged version in the [dylan-tool
 repository](https://github.com/dylan-lang/dylan-tool).
 
-**Important:** This Action must be used **after**
-[actions/checkout@v3](https://github.com/actions/checkout) when using the
-default `path:` (i.e., the current directory) because `actions/checkout@v3`
-deletes everything in the repo directory first.
-
-When this Action has completed, three artifacts exist in the current directory:
-
-1.  A symbolic link to the `dylan` executable.
-
-2.  A symbolic link to the `dylan-compiler` executable.
-
-3.  A symbolic link named `opendylan` that points to the Open Dylan
-    installation directory.
+When this Action has completed the `dylan` executable is available on the
+`PATH` and the `dylan-tool` directory contains the `dylan-tool` checkout and
+build products.
 
 See the [hello](https://github.com/cgay/hello) repository for the canonical
 example of using this Action.

--- a/action.yml
+++ b/action.yml
@@ -1,37 +1,31 @@
 # Use this action if you need a version of dylan-tool newer than the one in the
 # most recent Open Dylan release.  Normally it shouldn't be necessary to use
-# this action since the install-opendylan action installs dylan-tool itself.
+# this action since the install-opendylan action installs dylan-tool in its own
+# bin directory.
 
 name: install-dylan-tool
-description: Install a specific version of dylan-tool
+description: Install the dylan command-line tool
 inputs:
   tag:
     required: false
     type: string
-    default: v0.8.0
+    default: v0.11.0
 
 runs:
   using: composite
   steps:
     - uses: dylan-lang/install-opendylan@v3
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: dylan-lang/dylan-tool
         submodules: recursive
         ref: ${{ inputs.tag }}
-        # Must be under ${GITHUB_WORKSPACE}. We mv this below.
         path: dylan-tool
 
-    - name: Build dylan-tool
+    - name: Build and install dylan-tool
       shell: bash
       run: |
-        TOP=$(realpath ${GITHUB_WORKSPACE}/..)
-        cd ${TOP}
-        # Remove the link install-opendylan@v3 creates itself.
-        rm -f dylan
-        mv ${GITHUB_WORKSPACE}/dylan-tool .
-        DYLAN=${TOP} make -C dylan-tool install
-        ln -s install/dylan-tool/bin/dylan-tool-app dylan
+        DYLAN=${GITHUB_WORKSPACE}/dylan-tool make -C dylan-tool install
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
-        echo "${PWD}" >> ${GITHUB_PATH}
+        echo "${GITHUB_WORKSPACE}/dylan-tool/install/bin" >> ${GITHUB_PATH}


### PR DESCRIPTION
* Update default dylan-tool version to 0.11.0.
* Fix build-and-test.yml to
  - actually use the modified version of the Action
  - publish test results
* Add `dylan` to PATH but otherwise don't mess around with links and all that.
* Use checkout@v4.
* Update README.md